### PR TITLE
Sky

### DIFF
--- a/dyn/dyn_raffle_sql.py
+++ b/dyn/dyn_raffle_sql.py
@@ -1,11 +1,19 @@
 import sqlite3  # sqlite是个很灵活的东西，会自动转换，但是如果错误type且无法转换那么也不报错,传说中的沙雕feature https://www.sqlite.org/faq.html#q3
-from os import path
+import os
+import sys
 
 from .bili_data_types import DynRaffleStatus, DynRaffleJoined, DynRaffleResults, DynRaffleLuckydog
-
+appPath = ""
+if hasattr(sys, '_MEIPASS'):
+    # PyInstaller会创建临时文件夹temp
+    # 并把路径存储在_MEIPASS中
+    appPath = os.path.dirname(os.path.realpath(sys.executable))
+else:
+    appPath, filename = os.path.split(os.path.abspath(__file__))
 
 # 设计理由是execute script from another directory时，保证仍然可以正确执行（与conf读取设计一致，后续config读取也将自己控制，不再由main控制）
-conn = sqlite3.connect(f'{path.dirname(path.realpath(__file__))}/data.db')
+
+conn = sqlite3.connect(f'{appPath}/data.db')
 
 
 class OthersTable:

--- a/substance/substance_raffle_sql.py
+++ b/substance/substance_raffle_sql.py
@@ -1,11 +1,18 @@
 import sqlite3  # sqlite是个很灵活的东西，会自动转换，但是如果错误type且无法转换那么也不报错,传说中的沙雕feature https://www.sqlite.org/faq.html#q3
-from os import path
+import os
+import sys
 
 from .bili_data_types import \
     SubstanceRaffleStatus, SubstanceRaffleJoined, SubstanceRaffleResults, SubstanceRaffleLuckydog
-
+appPath = ""
+if hasattr(sys, '_MEIPASS'):
+    # PyInstaller会创建临时文件夹temp
+    # 并把路径存储在_MEIPASS中
+    appPath = os.path.dirname(os.path.realpath(sys.executable))
+else:
+    appPath, filename = os.path.split(os.path.abspath(__file__))
 # 设计理由是execute script from another directory时，保证仍然可以正确执行（与conf读取设计一致，后续config读取也将自己控制，不再由main控制）
-conn = sqlite3.connect(f'{path.dirname(path.realpath(__file__))}/data.db')
+conn = sqlite3.connect(f'{appPath}/data.db')
 
 
 class OthersTable:


### PR DESCRIPTION
pyinstaller打包好一个exe后，运行此exe，会把此文件解压缩到
C:\Users\xxxx\AppData\Local\Temp\ 目录下，然后运行。
而配置文件一般放置在exe同级别目录下。假如os.path.dirname(os.path.realpath(__file__))
来获取目录，会定位到解压缩后的地址。
瞎改的凑合看吧
参考：https://blog.csdn.net/weixin_33670786/article/details/92267914